### PR TITLE
Witching Hour and RoS Resurrect Cards Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Displays taunt minions that have died.
 * **Bloodraver Gul'dan**
 Displays friendly demons that have died.
 
-* **Resurrect** or **Onyx Bishop** or **Eternal Servitude** or **Kazakus**
+* **Resurrect** or **Onyx Bishop** or **Eternal Servitude** or **Lesser Diamond Spellstone** or  **Mass Resurrection** or **Catrina Muerte** or **Kazakus**
 Displays resurrect chance next to each minion that has died.
 
 * **Cruel Dinomancer**

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Displays resurrect chance next to each minion that has died.
 * **Cruel Dinomancer**
 Displays resurrect chance next to each minion that has been discarded.
 
+* **Nine Lives**
+Displays friendly deathrattle minions that have died.
+
+* **Witching Hour**
+Displays friendly beasts that have died.
+
 ## Installing
 1. Download *Graveyard.zip* from [here](https://github.com/RedHatter/Graveyard/releases).
 2. If needed, unblock the zip file before unzipping, by [right-clicking it and choosing properties](http://blogs.msdn.com/b/delay/p/unblockingdownloadedfile.aspx):

--- a/app.config
+++ b/app.config
@@ -67,6 +67,9 @@
             <setting name="NineLivesEnabled" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="WitchingHourEnabled" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Graveyard.src.Settings>
     </userSettings>
 </configuration>

--- a/src/Graveyard.cs
+++ b/src/Graveyard.cs
@@ -26,6 +26,7 @@ namespace HDT.Plugins.Graveyard
 		public ShudderwockView Shudderwock;
 		public DragoncallerAlannaView DragoncallerAlanna;
         public NineLivesView NineLives;
+        public WitchingHourView WitchingHour;
 
 		private StackPanel _friendlyPanel;
 		private StackPanel _enemyPanel;
@@ -198,6 +199,15 @@ namespace HDT.Plugins.Graveyard
             {
                 NineLives = null;
             }
+            if (Settings.Default.WitchingHourEnabled && WitchingHourView.isValid())
+            {
+                WitchingHour = new WitchingHourView();
+                _friendlyPanel.Children.Add(WitchingHour);
+            }
+            else
+            {
+                WitchingHour = null;
+            }
         }
 
 		public void PlayerGraveyardUpdate(Card card)
@@ -208,7 +218,8 @@ namespace HDT.Plugins.Graveyard
 			var guldan = Guldan?.Update(card) ?? false;
 			var rez = Resurrect?.Update(card) ?? false;
             var ninel = NineLives?.Update(card) ?? false;
-			if (!(any || nzoth || hadr || guldan || rez || ninel))
+            var witch = WitchingHour?.Update(card) ?? false;
+			if (!(any || nzoth || hadr || guldan || rez || ninel || witch))
 			{
 				Normal?.Update(card);
 			}

--- a/src/GraveyardPlugin.cs
+++ b/src/GraveyardPlugin.cs
@@ -27,7 +27,7 @@ demons for Bloodreaver Gul'dan,
 resurrect chance for priest resurrect cards,
 Murloc minions with a damage calculator for Anyfin Can Happen,
 resurrect chance for Cruel Dinomancer
-and possible minions for Nine Lives."; }
+possible minions for Nine Lives and Witching Hour."; }
 		}
 
 		public MenuItem MenuItem

--- a/src/NineLivesView.cs
+++ b/src/NineLivesView.cs
@@ -8,7 +8,7 @@ namespace HDT.Plugins.Graveyard
 	{
 		public static bool isValid()
 		{
-			return Core.Game.Player.PlayerCardList.FindIndex(card => card.Id == "DAL_377") > -1;
+			return Core.Game.Player.PlayerCardList.FindIndex(card => card.Id == HearthDb.CardIds.Collectible.Hunter.NineLives) > -1;
 		}
 
 		public NineLivesView()

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Graveyard")]
-[assembly: AssemblyCopyright("Copyright © 2017")]
+[assembly: AssemblyCopyright("Copyright © 2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/ResurrectView.cs
+++ b/src/ResurrectView.cs
@@ -14,6 +14,8 @@ namespace HDT.Plugins.Graveyard
 				card.Id == HearthDb.CardIds.Collectible.Priest.OnyxBishop ||
 				card.Id == HearthDb.CardIds.Collectible.Priest.EternalServitude ||
 				card.Id == HearthDb.CardIds.Collectible.Priest.LesserDiamondSpellstone ||
+                card.Id == HearthDb.CardIds.Collectible.Priest.MassResurrection ||
+                card.Id == HearthDb.CardIds.Collectible.Priest.CatrinaMuerte ||
 				(Settings.Default.ResurrectKazakus && card.Id == HearthDb.CardIds.Collectible.Neutral.Kazakus)) > -1;
 		}
 

--- a/src/Settings.Designer.cs
+++ b/src/Settings.Designer.cs
@@ -255,5 +255,20 @@
                 this["NineLivesEnabled"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool WitchingHourEnabled
+        {
+            get
+            {
+                return ((bool)(this["WitchingHourEnabled"]));
+            }
+            set
+            {
+                this["WitchingHourEnabled"] = value;
+            }
+        }
     }
 }

--- a/src/SettingsView.xaml
+++ b/src/SettingsView.xaml
@@ -55,7 +55,7 @@
 					<Label Content="Scale" VerticalAlignment="Center" DockPanel.Dock="Left" />
 				</DockPanel>
 		<TextBlock Text="Resurrect" Style="{StaticResource TitleStyle}"/>
-		<TextBlock Text="When the deck contains 'Resurrect', 'Onyx Bishop', 'Eternal Servitude', or 'Lesser Diamond Spellstone', show the resurrect chance of friendly  minions that have died." Style="{StaticResource DescStyle}"/>
+		<TextBlock Text="When the deck contains 'Resurrect', 'Onyx Bishop', 'Eternal Servitude', 'Lesser Diamond Spellstone', 'Mass Resurrection' or 'Catrina Muerte', show the resurrect chance of friendly  minions that have died." Style="{StaticResource DescStyle}"/>
 		<mah:ToggleSwitch IsChecked="{Binding ResurrectEnabled, Source={x:Static local:Settings.Default}}" ToolTip="Enable/Disable display for resurrect chances." Style="{StaticResource ToggleStyle}"/>
 		<TextBlock Text="Also show when the deck contains 'Kazakus'." Style="{StaticResource DescStyle}"/>
 		<mah:ToggleSwitch IsChecked="{Binding ResurrectKazakus, Source={x:Static local:Settings.Default}}" ToolTip="Enable/Disable display for resurrect chances with Kazakus." Style="{StaticResource ToggleStyle}"/>
@@ -83,5 +83,8 @@
         <TextBlock Text="Nine Lives" Style="{StaticResource TitleStyle}"/>
         <TextBlock Text="When the deck contains 'Nine Lives', show friendly deathrattle minions that died this game." Style="{StaticResource DescStyle}"/>
         <mah:ToggleSwitch IsChecked="{Binding NineLivesEnabled, Source={x:Static local:Settings.Default}}" ToolTip="Enable/Disable display for deathrattle minions." Style="{StaticResource ToggleStyle}"/>
+        <TextBlock Text="Witching Hour" Style="{StaticResource TitleStyle}"/>
+        <TextBlock Text="When the deck contains 'Witching Hour', show friendly beasts that died this game." Style="{StaticResource DescStyle}"/>
+        <mah:ToggleSwitch IsChecked="{Binding WitchingHourEnabled, Source={x:Static local:Settings.Default}}" ToolTip="Enable/Disable display for beasts." Style="{StaticResource ToggleStyle}"/>
     </StackPanel>
 </ScrollViewer>

--- a/src/ShudderwockView.cs
+++ b/src/ShudderwockView.cs
@@ -12,7 +12,7 @@ namespace HDT.Plugins.Graveyard
 	{
 		public static bool isValid()
 		{
-			return Core.Game.Player.PlayerCardList.FindIndex(card => card.Id == "GIL_820") > -1;
+			return Core.Game.Player.PlayerCardList.FindIndex(card => card.Id == HearthDb.CardIds.Collectible.Shaman.Shudderwock) > -1;
 		}
 
 		public ShudderwockView()

--- a/src/WitchingHourView.cs
+++ b/src/WitchingHourView.cs
@@ -1,0 +1,24 @@
+using Hearthstone_Deck_Tracker;
+using Hearthstone_Deck_Tracker.Hearthstone;
+
+namespace HDT.Plugins.Graveyard
+{
+	public class WitchingHourView : NormalView
+	{
+		public static bool isValid()
+		{
+			return Core.Game.Player.PlayerCardList.FindIndex(card => card.Id == HearthDb.CardIds.Collectible.Druid.WitchingHour) > -1;
+		}
+
+		public WitchingHourView()
+		{
+			// Section Label
+			Label.Text = "Witching Hour";
+		}
+
+		new public bool Update(Card card)
+		{
+			return card.Race == "Beast" && base.Update(card);
+		}
+	}
+}


### PR DESCRIPTION
The following changes have been made:

* "Witching Hour" (The Witchwood) is now supported with an own view.
* Resurrect Cards from RoS ("Mass Resurrection" and "Catrina Muerte") now use the resurrect view.
* Several minor changes to the README.md
* HearthDb.dll was updated to the latest version. Therefore "Shudderwock" and "Nine Lives" cards use the actual name instead of the card id in the code.
* Assembly Info's copyright is set to 2019.

That's it. Comment if there are any issues!